### PR TITLE
Create snippet: Override Stat Entry

### DIFF
--- a/snippets/bg3.code-snippets
+++ b/snippets/bg3.code-snippets
@@ -27,6 +27,17 @@
             "end)\n"
         ]
     },
+    "Override Stat Entry": {
+        "prefix": ["new", "override"],
+        "description": "Create an override for an existing Stat Entry",
+        "scope": "plaintext",
+        "body": [
+            "new entry \"$1\"",
+            "type \"SpellData\"",
+            "using \"$1\"",
+            "data $0"
+        ]
+    },
     "Script-Extender-Config": {
         "prefix": ["cfg", "Config.json"],
         "description": "Script-Extender-Config",


### PR DESCRIPTION
Create a snippet to quickly generate a stat entry. (Fixes #5)

```
new entry "$1"
data "SpellData"
using "$1"
data $0
```